### PR TITLE
Refactor Sack to be a child of Haversack::ItemCollection

### DIFF
--- a/haversack.gemspec
+++ b/haversack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib/haversack.rb"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "factory_bot", "~> 4.0"

--- a/lib/haversack.rb
+++ b/lib/haversack.rb
@@ -3,4 +3,5 @@ module Haversack
   require "haversack/sack"
   require "haversack/item"
   require "haversack/err"
+  require "haversack/itemcollection"
 end

--- a/lib/haversack/itemcollection.rb
+++ b/lib/haversack/itemcollection.rb
@@ -3,7 +3,7 @@ module Haversack
 
     def initialize(data, &block)
       if !block_given?
-        raise ArgumentError, "expected #{data} to contain only elements of class Haversack::Item" unless data.is_a?(Array) && only_items?(data)
+        raise ArgumentError, "expected #{data} to contain only elements of class Haversack::Item" unless data.is_a?(Array) && ItemCollection.only_items?(data)
       end
 
       @size   = self.size
@@ -25,8 +25,7 @@ module Haversack
       super
     end
 
-    private
-    def only_items?(data)
+    def self.only_items?(data)
       data.all? { |el| el.is_a? Haversack::Item }
     end
     

--- a/lib/haversack/sack.rb
+++ b/lib/haversack/sack.rb
@@ -1,79 +1,61 @@
-class Sack
-  include Enumerable
+require 'haversack/itemcollection'
 
-  attr_reader :capacity, :weight, :available_capacity, :current_weight, :contents
+class Sack < Haversack::ItemCollection
 
-  def initialize(capacity:, weight:, contents: nil)
-    @capacity           = capacity
-    @weight             = weight
-    self.contents       = contents || [] ## Use the setter to enforce weight/capacity restrictions
-    @current_weight     = self.current_weight
-    @available_capacity = self.available_capacity
-  end
-
-  def method_missing(method_id)
-    Enumerable.respond_to? method_id ? @contents.send(method_id) : raise(NoMethodError)
-  end
+  attr_accessor :capacity
+  attr_accessor :max_weight
   
-  def contents=(new_contents)
-    raise Haversack::KnapsackContentError          if has_non_items? new_contents
-    raise Haversack::KnapsackCapacityExceededError if exceeds_capacity? new_contents
-    raise Haversack::KnapsackWeightExceededError   if exceeds_weight? new_contents
+  def initialize(data, capacity:, max_weight:, &block)
     
-    @contents = new_contents
-  end
+    @capacity   = capacity
+    @max_weight = max_weight
+    
+    block_given? ? super(data, &block) : super(data)
+    
+    raise Haversack::KnapsackCapacityExceededError if contents_exceed_capacity?
+    raise Haversack::KnapsackWeightExceededError   if contents_exceed_weight?
+    end
 
-  def has_non_items?(contents) ## TODO: Consider refactor: Static method?  Doesn't rely on instance data.
-    contents.any? { |e| !e.is_a? Haversack::Item }
-  end
-
-  def current_weight
-    @contents.empty? ? 0 : @contents.map { |item| item.weight }.sum
-  end
-
-  ## TODO: the *fit* methods duplicate behavior.  Consolidate them in a future itteration.
-  
-  def fits_item_weight?(item)
-    item.weight + @current_weight <= @weight
+  def available_weight
+    empty? ? @max_weight : (@max_weight - weight)
   end
 
   def available_capacity
-    @contents.empty? ? @capacity : (@capacity - @contents.length)
+    empty? ? @capacity : (@capacity - size)
   end
 
-  def fits_item_capacity?(item)
-    item.size < @available_capacity
+  def fits_weight?(item)
+    item.weight <= available_weight
   end
 
+  def exceeds_weight?(item)
+    !fits_weight?(item)
+  end
+  
+  def fits_capacity?(item)
+    item.size <= available_capacity
+  end
+
+  def exceeds_capacity?(item)
+    !fits_capacity?(item)
+  end
+    
   def fits_item?(item)
-    (item.is_a? Haversack::Item) && (fits_item_capacity?(item) && fits_item_weight?(item))
+    item.is_a?(Haversack::Item) && fits_capacity?(item) && fits_weight?(item)
   end
-
-  def push(item) ## TODO: Return an error that describes which constraint failed
-    fits_item? item ? @contents.push(item) : raise(Haversack::KnapsackContentError)
-    @contents
+  alias :fits? :fits_item?
+  
+  def push(item) ## TODO: Describe which constraint failed
+    fits_item?(item) ? super : raise(Haversack::KnapsackContentError)
   end
-
-  def fits_contents?(contents)
-    fits_weight?(contents) && fits_capacity?(contents)
+  
+  private
+  def contents_exceed_weight?
+    weight > @max_weight
   end
-
-  def fits_weight?(contents)
-    new_weight = contents.map { |item| item.weight }.sum
-    new_weight <= @weight
+  
+  def contents_exceed_capacity?
+    size > @capacity
   end
-
-  def exceeds_weight?(contents)
-    !fits_weight? contents
-  end
-
-  def fits_capacity?(contents)
-    new_capacity = contents.map { |item| item.size }.sum
-    new_capacity <= @capacity
-  end
-
-  def exceeds_capacity?(contents)
-    !fits_capacity? contents
-  end
-
+  
 end

--- a/spec/factories/item_factory.rb
+++ b/spec/factories/item_factory.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     factory :heavy_item do
       weight { 2 }
     end
-    
+
     initialize_with { new(weight:weight, size:size) }
   end
 end

--- a/spec/factories/sack_factory.rb
+++ b/spec/factories/sack_factory.rb
@@ -1,16 +1,21 @@
 FactoryBot.define do
   factory :sack do
-    capacity { 10 }
-    weight   { 10 }
-
-    initialize_with { new(capacity:capacity, weight:weight) }
+    capacity   { 10 }
+    max_weight { 10 }
     
+    
+    initialize_with { new(10, capacity:capacity, max_weight:max_weight) {|i| build(:item) } }
+
+    factory :empty_sack do
+      initialize_with { new(0, capacity:capacity, max_weight:max_weight) {|i| build(:item) } }
+    end
+
     factory :filled_sack do
-      contents { Array.new(capacity) { build(:item) } }
+      initialize_with { new(capacity, capacity:capacity, max_weight:max_weight) { build(:item) } }
     end
 
     factory :near_full_sack do
-      contents { Array.new(capacity - 1) { build(:item) } }
+      initialize_with { new(capacity - 1, capacity:capacity, max_weight:max_weight) { build(:item) } }
     end
   end
 end

--- a/spec/itemcollection_spec.rb
+++ b/spec/itemcollection_spec.rb
@@ -57,7 +57,32 @@ describe Haversack::ItemCollection do
         expect(@collection.last).to eql uniq_item
       end
     end
-    
+  end
+
+  describe '#only_items?' do
+    context 'given data with no items' do
+      let(:non_item_array) { Array(1..10) }
+      
+      it 'returns false' do
+        expect(Haversack::ItemCollection.only_items? non_item_array).to be false
+      end
+    end
+
+    context 'given data with only items' do
+      let(:item_array) { Array.new(10) { build(:item) } }
+
+      it 'returns true' do
+        expect(Haversack::ItemCollection.only_items? item_array).to be true
+      end
+    end
+
+    context 'given an empty data array' do
+      let(:empty_array) { Array.new }
+
+      it 'returns true' do
+        expect(Haversack::ItemCollection.only_items? empty_array).to be true
+      end
+    end
   end
   
 end

--- a/spec/sack_spec.rb
+++ b/spec/sack_spec.rb
@@ -6,145 +6,83 @@ describe Sack do
   describe '#initialize' do
     context 'when no capacity parameter is present' do
       it 'raises an ArgumentError' do
-        expect { Sack.new(weight: 10) }.to raise_error ArgumentError
+        expect { Sack.new(10, max_weight: 10) {|i| build(:item) } }.to raise_error ArgumentError
       end
     end
 
-    context 'when no weight parameter is present' do
+    context 'when no max_weight parameter is present' do
       it 'raises an ArgumentError' do
-        expect { Sack.new(capacity: 10) }.to raise_error ArgumentError
+        expect { Sack.new(10, capacity: 10) }.to raise_error ArgumentError
       end
     end
 
     context 'when given the capacity and weight parameters' do
-      it 'successfully creates a new empty Sack' do
-        expect(Sack.new(capacity: 10, weight: 10)).to be_a_kind_of Sack
+      it 'successfully creates a new Sack' do
+        expect(Sack.new(10, capacity: 10, max_weight: 10) {|i| build(:item)} ).to be_a_kind_of Sack
       end
     end
   end
 
-  describe '.contents=' do
-    let(:contents)          { @sack.contents }
-    let(:capacity)          { @sack.capacity }
-    let(:weight)            { @sack.weight }
-    let(:exceeded_capacity) { Array.new(capacity + 1) { build(:item) } }
-    let(:exceeded_weight)   { Array.new(capacity) { build(:item, weight: weight + 1) } }
-    let(:non_item_contents) { Array.new(5) }
-    let(:item_contents)     { Array.new(5) { build(:item) } }
-    
-    context 'when the new contents exceed capacity' do
-      it 'raises a KnapsackCapacityExceededError' do
-        expect { @sack.contents = exceeded_capacity }.to raise_error Haversack::KnapsackCapacityExceededError
-      end
-
-    end
-
-    context 'when the new contents exceed weight' do
-      it 'raises a KnapsackWeightExceededError' do
-        expect { @sack.contents = exceeded_weight }.to raise_error Haversack::KnapsackWeightExceededError
-      end
-    end
-
-    context 'when at least one member of the contents array is not an Item' do
-      it 'raises a KnapsackContentError' do
-        expect { @sack.contents = non_item_contents }.to raise_error Haversack::KnapsackContentError
-      end
-    end
-    
-  end
-
-  describe '.has_non_items?' do
-    let(:non_item_contents) { Array.new(5) }
-    let(:item_contents)     { Array.new(5) { build(:item) } }
-
-    context 'when given a list containing a non-item' do
-      it 'returns true' do
-        expect(@sack.has_non_items? non_item_contents).to be true
-      end
-    end
-  
-    context 'when given a list containing only items' do
-      it 'returns false' do
-        expect(@sack.has_non_items? item_contents).to be false
-      end
-    end
-  end
-
-  describe '.current_weight' do
-    let(:filled_sack) { build(:filled_sack) }
-    let(:empty_sack)  { build(:sack) }
-    
-    context 'when given a sack with a total weight of 10' do
-      it 'calculates the current weight as 10' do
-        expect(filled_sack.current_weight).to be 10
-      end
-    end
-
-    context 'when given an empty sack' do
-      it 'calculates the current weight as 0' do
-        expect(empty_sack.current_weight).to be 0
-      end
-    end
-    
-  end
-
-  describe '.fits_item_weight?' do
-    let(:overweight_item)    { build(:item, weight: @sack.weight + 1) }
-    let(:within_weight_item) { build(:item) }
-
-    context 'when the item would exceed weight' do
-      it 'returns false' do
-        expect(@sack.fits_item_weight? overweight_item).to be false
-      end
-    end
-
-    context 'when the item would fit weight' do
-      it 'returns true' do
-        expect(@sack.fits_item_weight? within_weight_item).to be true
-      end
-    end
-  end
-
-  describe '.available_capacity' do
-    let(:empty_sack)     { build(:sack) }
-    let(:filled_sack)    { build(:filled_sack) }
-    let(:near_full_sack) { build(:near_full_sack) }
-
+  describe '.available_weight' do
     context 'when given a near full sack' do
+      let(:near_full_sack) { build(:near_full_sack) }
+
+      it 'calculates the available weight as 1' do
+        expect(near_full_sack.available_weight).to be 1
+      end
+    end
+    
+    context 'when given a filled sack' do
+      let(:filled_sack) { build(:filled_sack) }
+
+      it 'calculates the available weight as 0' do
+        expect(filled_sack.available_weight).to be 0
+      end
+    end
+  end
+  
+  describe '.available_capacity' do
+    context 'when given a near full sack' do
+      let(:near_full_sack) { build(:near_full_sack) }
+      
       it 'calculates the available capacity as 1' do
         expect(near_full_sack.available_capacity).to be 1
       end
     end
     
     context 'when given a filled sack' do
-      it 'calculates the current capacity as 0' do
+      let(:filled_sack) { build(:filled_sack) }
+      
+      it 'calculates the available capacity as 0' do
         expect(filled_sack.available_capacity).to be 0
       end
     end
 
     context 'when given an empty sack with a capacity of 10' do
+      let(:empty_sack) { build(:empty_sack) }
+      
       it 'calculates the available capacity as 10' do
         expect(empty_sack.available_capacity).to be 10
       end
     end
-
   end
 
-
-  describe '.fits_item_capacity?' do
+  describe '.fits_capacity?' do
     let(:near_full_sack) { build(:near_full_sack) }
-    let(:large_item)     { build(:large_item, size: 10) }
-    let(:small_item)     { build(:item) }
     
     context 'when the item would exceed capacity' do
+      let(:large_item) { build(:large_item) }
+      
       it 'returns false' do
-        expect(near_full_sack.fits_item_capacity? large_item).to be false
+        expect(near_full_sack.fits_capacity? large_item).to be false
       end
     end
 
     context 'when the item would fit capacity' do
+      let(:small_item) { build(:item) }
+      
       it 'returns true' do
-        expect(near_full_sack.fits_item_capacity? small_item).to be true
+        expect(near_full_sack.fits_capacity? small_item).to be true
       end
     end
   end
@@ -156,7 +94,7 @@ describe Sack do
       end
     end
 
-    ## Skipping.  Tested in .fits_item_weight? and .fits_item_capacity?
+    ## Skipping.  Tested in .fits_weight? and .fits_capacity?
     xcontext 'given an item that would exceed weight' do 
       it 'returns false' do
       end
@@ -180,85 +118,105 @@ describe Sack do
 
   describe '.push' do
     let(:item)       { build(:item) }
-    let(:large_item) { build(:large_item) }
+    let(:empty_sack) { build(:empty_sack) }
+    
+    context 'when pushing an item' do
+      it 'pushes an item successfully' do
+        expect { empty_sack.push(item) }.not_to raise_error
+        expect(empty_sack.include? item).to be true
+      end
+    end
 
-    it 'pushes an item successfully' do
-      @sack.push item
-      expect(@sack.contents.include? item).to be true
+    context 'when pushing an item that would exceed weight' do
+      let(:near_full_sack) { build(:near_full_sack) }
+      let(:heavy_item)     { build(:heavy_item) }
+      
+      it 'raises a KnapsackContentError' do
+        expect { near_full_sack.push heavy_item }.to raise_error Haversack::KnapsackContentError
+      end
+    end
+
+    context 'when pushing an item that would exceed capacity' do
+      let(:near_full_sack) { build(:near_full_sack) }
+      let(:large_item) { build(:large_item) }
+
+      it 'raises a KnapsackContentError' do
+        expect { near_full_sack.push large_item }.to raise_error Haversack::KnapsackContentError
+      end
     end
     
   end
 
-  xdescribe '.fits_contents?' do
-  end
-
   describe '.fits_weight?' do
-    let(:exceeds_weight_contents) { Array.new(@sack.capacity) { build(:heavy_item) } }
-    let(:fits_weight_contents)    { Array.new(@sack.capacity) { build(:item) } }
+    let(:near_full_sack) { build(:near_full_sack) }
+    let(:heavy_item)     { build(:heavy_item) }
+    let(:item)           { build(:item) }
     
-    context 'given a set of contents that exceeds weight' do
+    context 'given an item that exceeds weight' do
       it 'returns false' do
-        expect(@sack.fits_weight? exceeds_weight_contents).to be false
+        expect(near_full_sack.fits_weight? heavy_item).to be false
       end
     end
 
     context 'given a set of contents that fits weight' do
       it 'returns true' do
-        expect(@sack.fits_weight? fits_weight_contents).to be true
+        expect(near_full_sack.fits_weight? item).to be true
       end
     end
   end
 
   describe '.exceeds_weight?' do
-    let(:exceeds_weight_contents) { Array.new(@sack.capacity) { build(:heavy_item) } }
-    let(:fits_weight_contents)    { Array.new(@sack.capacity) { build(:item) } }
-    
+    let(:near_full_sack) { build(:near_full_sack) }
+    let(:heavy_item)     { build(:heavy_item) }
+    let(:item)           { build(:item) }
+
     context 'given a set of contents that exceeds weight' do
       it 'returns true' do
-        expect(@sack.exceeds_weight? exceeds_weight_contents).to be true
+        expect(near_full_sack.exceeds_weight? heavy_item).to be true
       end
     end
     
     context 'given a set of contents that fits weight' do
       it 'returns false' do
-        expect(@sack.exceeds_weight? fits_weight_contents).to be false
+        expect(near_full_sack.exceeds_weight? item).to be false
       end
     end
   end
   
   describe '.fits_capacity?' do
-    let(:exceeds_capacity_contents) { Array.new(@sack.capacity) { build(:large_item) } }
-    let(:fits_capacity_contents)    { Array.new(@sack.capacity) { build(:item) } }
+    let(:near_full_sack) { build(:near_full_sack) }
+    let(:large_item)     { build(:large_item) }
+    let(:item)           { build(:item) }
     
-    context 'given a set of contents that exceeds capacity' do
+    context 'given an item that exceeds capacity' do
       it 'returns false' do
-        expect(@sack.fits_capacity? exceeds_capacity_contents).to be false
+        expect(near_full_sack.fits_capacity? large_item).to be false
       end
     end
 
-    context 'given a set of contents that fits capacity' do
+    context 'given a set of contents that fits weight' do
       it 'returns true' do
-        expect(@sack.fits_capacity? fits_capacity_contents).to be true
+        expect(near_full_sack.fits_capacity? item).to be true
       end
     end
   end
 
   describe '.exceeds_capacity?' do
-    let(:exceeds_capacity_contents) { Array.new(@sack.capacity) { build(:large_item) } }
-    let(:fits_capacity_contents)    { Array.new(@sack.capacity) { build(:item) } }
-    
-    context 'given a set of contents that exceeds capacity' do
-      it 'returns true' do
-        expect(@sack.exceeds_capacity? exceeds_capacity_contents).to be true
-      end
-    end
+    let(:near_full_sack) { build(:near_full_sack) }
+    let(:large_item)     { build(:large_item) }
+    let(:item)           { build(:item) }
 
-    context 'given a set of contents that fits capacity' do
-      it 'returns false' do
-        expect(@sack.exceeds_capacity? fits_capacity_contents).to be false
+    context 'given a set of contents that exceeds weight' do
+      it 'returns true' do
+        expect(near_full_sack.exceeds_capacity? large_item).to be true
       end
     end
     
+    context 'given a set of contents that fits weight' do
+      it 'returns false' do
+        expect(near_full_sack.exceeds_capacity? item).to be false
+      end
+    end
   end
   
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
+  ## Fail fast
+  config.fail_fast = true
+  
   # Disable RSpec exposing methods globally on `Module` and `main`
   # config.disable_monkey_patching!
 


### PR DESCRIPTION
With the recent architectural decision to make `Sack` become a child of `Array`, I created the `Haversack::ItemCollection` class, which exposes methods and abstraction that will be useful in future projects.

This PR refactors the original `Sack` class to rely on its parent and remove duplicate behavior.